### PR TITLE
Attribute colors

### DIFF
--- a/index.less
+++ b/index.less
@@ -230,7 +230,8 @@
   }
 }
 
-.source .entity.name.tag {
+.source .entity.name.tag,
+.source .punctuation.tag {
   color: #96CBFE;
 }
 .source .entity.other.attribute-name {
@@ -270,8 +271,8 @@
     color: #494949;
   }
 
-  &.tag,
-  &.tag.inline,
+  &.tag .entity,
+  &.tag > .punctuation,
   &.tag.inline .entity {
     color: #C6C5FE;
   }


### PR DESCRIPTION
Proposing a fix for issue #4 by re-using the variable/parameter color to differentiate tag attributes. I believe a subtle difference between tag names and attributes enhances readability in htm and xml files.
![attributes](https://cloud.githubusercontent.com/assets/2543659/4964598/c975b9d6-6765-11e4-8f79-9c62b97df3d4.png)

While I’m at it also brings script tag punctuation in line with other tags.
![before](https://cloud.githubusercontent.com/assets/2543659/4964596/c1b56020-6765-11e4-9a78-17f5ae6b86f3.png)
![after](https://cloud.githubusercontent.com/assets/2543659/4964597/c3ebf390-6765-11e4-872b-8ee85ac9dc7a.png)
