### PR TITLE
Reflect the fact that atom-dark is no longer the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Atom Dark Syntax theme
 
-Default dark syntax theme for Atom.
+A dark syntax theme for Atom.
 
 This theme is installed by default with Atom and can be activated by going to
 the _Themes_ section in the Settings view (`cmd-,`) and selecting it from the

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "atom-dark-syntax",
   "theme": "syntax",
   "version": "0.26.0",
-  "description": "Default dark theme for syntax",
+  "description": "A dark theme for syntax",
   "repository": "https://github.com/atom/atom-dark-syntax",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
This changed in atom v0.188.0