### PR TITLE
Language variables

### DIFF
--- a/index.less
+++ b/index.less
@@ -124,10 +124,10 @@ atom-text-editor, :host {
 }
 
 .keyword {
-  color: @syntax-color-keyword;
+  color: #96CBFE;
 
   &.control {
-    color: @syntax-color-keyword;
+    color: #96CBFE;
   }
 
   &.operator {
@@ -144,7 +144,7 @@ atom-text-editor, :host {
 }
 
 .constant {
-  color: @syntax-color-constant;
+  color: #99CC99;
 
   &.numeric {
     color: #FF73FD;
@@ -152,7 +152,7 @@ atom-text-editor, :host {
 }
 
 .variable {
-  color: @syntax-color-variable;
+  color: #C6C5FE;
 }
 
 .invalid.deprecated {
@@ -216,7 +216,7 @@ atom-text-editor, :host {
   color: #FFFFB6;
 
   &.function {
-    color: @syntax-color-function;
+    color: #DAD085;
   }
 
   &.constant {
@@ -224,21 +224,21 @@ atom-text-editor, :host {
   }
 
   &.type.property-name.css {
-    color: @syntax-color-property;
+    color: #EDEDED;
   }
 }
 
 .source .entity.name.tag,
 .source .punctuation.tag {
-  color: @syntax-color-tag;
+  color: #96CBFE;
 }
 .source .entity.other.attribute-name {
-  color: @syntax-color-attribute;
+  color: #C6C5FE;
 }
 
 .entity {
   &.other.attribute-name {
-    color: @syntax-color-attribute;
+    color: #C6C5FE;
   }
 
   &.name.tag.namespace,
@@ -277,12 +277,12 @@ atom-text-editor, :host {
   &.tag .name,
   &.tag.inline .name,
   &.tag > .punctuation {
-    color: @syntax-color-tag;
+    color: #96CBFE;
   }
 
   &.selector.css .entity.name.tag {
     text-decoration: underline;
-    color: @syntax-color-tag;
+    color: #96CBFE;
   }
 
   &.selector.css .entity.other.attribute-name.tag.pseudo-class {
@@ -294,12 +294,12 @@ atom-text-editor, :host {
   }
 
   &.selector.css .entity.other.attribute-name.class {
-    color: @syntax-color-class;
+    color: #62B1FE;
   }
 
   &.property-group .support.constant.property-value.css,
   &.property-value .support.constant.property-value.css {
-    color: @syntax-color-value;
+    color: #F9EE98;
   }
 
   &.preprocessor.at-rule .keyword.control.at-rule {

--- a/index.less
+++ b/index.less
@@ -124,10 +124,10 @@ atom-text-editor, :host {
 }
 
 .keyword {
-  color: #96CBFE;
+  color: @syntax-color-keyword;
 
   &.control {
-    color: #96CBFE;
+    color: @syntax-color-keyword;
   }
 
   &.operator {
@@ -144,7 +144,7 @@ atom-text-editor, :host {
 }
 
 .constant {
-  color: #99CC99;
+  color: @syntax-color-constant;
 
   &.numeric {
     color: #FF73FD;
@@ -152,7 +152,7 @@ atom-text-editor, :host {
 }
 
 .variable {
-  color: #C6C5FE;
+  color: @syntax-color-variable;
 }
 
 .invalid.deprecated {
@@ -216,7 +216,7 @@ atom-text-editor, :host {
   color: #FFFFB6;
 
   &.function {
-    color: #DAD085;
+    color: @syntax-color-function;
   }
 
   &.constant {
@@ -224,21 +224,21 @@ atom-text-editor, :host {
   }
 
   &.type.property-name.css {
-    color: #EDEDED;
+    color: @syntax-color-property;
   }
 }
 
 .source .entity.name.tag,
 .source .punctuation.tag {
-  color: #96CBFE;
+  color: @syntax-color-tag;
 }
 .source .entity.other.attribute-name {
-  color: #C6C5FE;
+  color: @syntax-color-attribute;
 }
 
 .entity {
   &.other.attribute-name {
-    color: #C6C5FE;
+    color: @syntax-color-attribute;
   }
 
   &.name.tag.namespace,
@@ -277,12 +277,12 @@ atom-text-editor, :host {
   &.tag .name,
   &.tag.inline .name,
   &.tag > .punctuation {
-    color: #96CBFE;
+    color: @syntax-color-tag;
   }
 
   &.selector.css .entity.name.tag {
     text-decoration: underline;
-    color: #96CBFE;
+    color: @syntax-color-tag;
   }
 
   &.selector.css .entity.other.attribute-name.tag.pseudo-class {
@@ -294,12 +294,12 @@ atom-text-editor, :host {
   }
 
   &.selector.css .entity.other.attribute-name.class {
-    color: #62B1FE;
+    color: @syntax-color-class;
   }
 
   &.property-group .support.constant.property-value.css,
   &.property-value .support.constant.property-value.css {
-    color: #F9EE98;
+    color: @syntax-color-value;
   }
 
   &.preprocessor.at-rule .keyword.control.at-rule {

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -28,3 +28,17 @@
 @syntax-color-added: #A8FF60;
 @syntax-color-modified: #E9C062;
 @syntax-color-removed: #CC6666;
+
+// For language entity colors
+@syntax-color-variable: #C6C5FE;
+@syntax-color-constant: #99CC99;
+@syntax-color-property: #EDEDED;
+@syntax-color-value: #F9EE98;
+@syntax-color-function: #DAD085;
+@syntax-color-method: @syntax-color-function;
+@syntax-color-class: #62B1FE;
+@syntax-color-keyword: #96CBFE;
+@syntax-color-tag: #96CBFE;
+@syntax-color-attribute: #C6C5FE;
+@syntax-color-import: @syntax-color-keyword;
+@syntax-color-snippet: @syntax-color-constant;


### PR DESCRIPTION
This PR adds language variables used by Autocomplete plus https://github.com/atom-community/autocomplete-plus/issues/351

Not quite sure about the `@syntax-color-snippet` variable. Currently mapped to `@syntax-color-constant`.