### PR TITLE
Stop using shadow DOM selectors

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,6 +1,6 @@
 @import 'syntax-variables';
 
-atom-text-editor, :host {
+atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 
@@ -44,55 +44,61 @@ atom-text-editor, :host {
     background-color: @syntax-selection-color;
   }
 
+  .bracket-matcher .region {
+    border-bottom: 1px solid #f8de7e;
+    margin-top: -1px;
+    opacity: .7;
+  }
+
   // Markdown Styles
 
-  .source.gfm {
+  .syntax--source.syntax--gfm {
     color: #999;
   }
 
-  .gfm {
-    .markup.heading {
+  .syntax--gfm {
+    .syntax--markup.syntax--heading {
       color: #eee;
     }
 
-    .link {
+    .syntax--link {
       color: #555;
     }
 
-    .variable.list,
-    .support.quote {
+    .syntax--variable.syntax--list,
+    .syntax--support.syntax--quote {
       color: #555;
     }
 
-    .link .entity {
+    .syntax--link .syntax--entity {
       color: #ddd;
     }
 
-    .raw {
+    .syntax--raw {
       color: #aaa;
     }
   }
 
-  .markdown {
-    .paragraph {
+  .syntax--markdown {
+    .syntax--paragraph {
       color: #999;
     }
 
-    .heading {
+    .syntax--heading {
       color: #eee;
     }
 
-    .raw {
+    .syntax--raw {
       color: #aaa;
     }
 
-    .link {
+    .syntax--link {
       color: #555;
 
-      .string {
+      .syntax--string {
         color: #555;
 
-        &.title {
+        &.syntax--title {
           color: #ddd;
         }
       }
@@ -100,238 +106,232 @@ atom-text-editor, :host {
   }
 }
 
-.bracket-matcher .region {
-  border-bottom: 1px solid #f8de7e;
-  margin-top: -1px;
-  opacity: .7;
-}
-
-.comment {
+.syntax--comment {
   color: #7C7C7C;
 }
 
-.entity {
+.syntax--entity {
   color: #FFD2A7;
 
-  &.name.type {
+  &.syntax--name.syntax--type {
     text-decoration: underline;
     color: #FFFFB6;
   }
 
-  &.other.inherited-class {
+  &.syntax--other.syntax--inherited-class {
     color: #9B5C2E;
   }
 }
 
-.keyword {
+.syntax--keyword {
   color: #96CBFE;
 
-  &.control {
+  &.syntax--control {
     color: #96CBFE;
   }
 
-  &.operator {
+  &.syntax--operator {
     color: #EDEDED;
   }
 }
 
-.storage {
+.syntax--storage {
   color: #CFCB90;
 
-  &.modifier {
+  &.syntax--modifier {
     color: #96CBFE;
   }
 }
 
-.constant {
+.syntax--constant {
   color: #99CC99;
 
-  &.numeric {
+  &.syntax--numeric {
     color: #FF73FD;
   }
 }
 
-.variable {
+.syntax--variable {
   color: #C6C5FE;
 }
 
-.invalid.deprecated {
+.syntax--invalid.syntax--deprecated {
   text-decoration: underline;
   color: #FD5FF1;
 }
 
-.invalid.illegal {
+.syntax--invalid.syntax--illegal {
   color: #FD5FF1;
   background-color: rgba(86, 45, 86, 0.75);
 }
 
 // String interpolation in Ruby, CoffeeScript, and others
-.string {
-  .source,
-  .meta.embedded.line {
+.syntax--string {
+  .syntax--source,
+  .syntax--meta.syntax--embedded.syntax--line {
     color: #EDEDED;
   }
 
-  .punctuation.section.embedded {
+  .syntax--punctuation.syntax--section.syntax--embedded {
     color: #00A0A0;
 
-    .source {
+    .syntax--source {
       color: #00A0A0;  // Required for the end of embedded strings in Ruby #716
     }
   }
 }
 
-.string {
+.syntax--string {
   color: #A8FF60;
 
-  .constant {
+  .syntax--constant {
     color: #00A0A0;
   }
 
-  &.regexp {
+  &.syntax--regexp {
     color: #E9C062;
 
-    .constant.character.escape,
-    .source.ruby.embedded,
-    .string.regexp.arbitrary-repetition {
+    .syntax--constant.syntax--character.syntax--escape,
+    .syntax--source.syntax--ruby.syntax--embedded,
+    .syntax--string.syntax--regexp.syntax--arbitrary-repetition {
       color: #FF8000;
     }
 
-    &.group {
+    &.syntax--group {
       color: #C6A24F;
       background-color: rgba(255, 255, 255, 0.06);
     }
 
-    &.character-class {
+    &.syntax--character-class {
       color: #B18A3D;
     }
   }
 
-  .variable {
+  .syntax--variable {
     color: #8A9A95;
   }
 }
 
-.support {
+.syntax--support {
   color: #FFFFB6;
 
-  &.function {
+  &.syntax--function {
     color: #DAD085;
   }
 
-  &.constant {
+  &.syntax--constant {
     color: #FFD2A7;
   }
 
-  &.type.property-name.css {
+  &.syntax--type.syntax--property-name.syntax--css {
     color: #EDEDED;
   }
 }
 
-.source .entity.name.tag,
-.source .punctuation.tag {
+.syntax--source .syntax--entity.syntax--name.syntax--tag,
+.syntax--source .syntax--punctuation.syntax--tag {
   color: #96CBFE;
 }
-.source .entity.other.attribute-name {
+.syntax--source .syntax--entity.syntax--other.syntax--attribute-name {
   color: #C6C5FE;
 }
 
-.entity {
-  &.other.attribute-name {
+.syntax--entity {
+  &.syntax--other.syntax--attribute-name {
     color: #C6C5FE;
   }
 
-  &.name.tag.namespace,
-  &.other.attribute-name.namespace {
+  &.syntax--name.syntax--tag.syntax--namespace,
+  &.syntax--other.syntax--attribute-name.syntax--namespace {
     color: #E18964;
   }
 }
 
-.meta {
-  &.preprocessor.c {
+.syntax--meta {
+  &.syntax--preprocessor.syntax--c {
     color: #8996A8;
   }
 
-  &.preprocessor.c .keyword {
+  &.syntax--preprocessor.syntax--c .syntax--keyword {
     color: #AFC4DB;
   }
 
-  &.cast {
+  &.syntax--cast {
     color: #676767;
   }
 
-  &.sgml.html .meta.doctype,
-  &.sgml.html .meta.doctype .entity,
-  &.sgml.html .meta.doctype .string,
-  &.xml-processing,
-  &.xml-processing .entity,
-  &.xml-processing .string {
+  &.syntax--sgml.syntax--html .syntax--meta.syntax--doctype,
+  &.syntax--sgml.syntax--html .syntax--meta.syntax--doctype .syntax--entity,
+  &.syntax--sgml.syntax--html .syntax--meta.syntax--doctype .syntax--string,
+  &.syntax--xml-processing,
+  &.syntax--xml-processing .syntax--entity,
+  &.syntax--xml-processing .syntax--string {
     color: #494949;
   }
 
-  &.tag .entity,
-  &.tag > .punctuation,
-  &.tag.inline .entity {
+  &.syntax--tag .syntax--entity,
+  &.syntax--tag > .syntax--punctuation,
+  &.syntax--tag.syntax--inline .syntax--entity {
     color: #C6C5FE;
   }
-  &.tag .name,
-  &.tag.inline .name,
-  &.tag > .punctuation {
+  &.syntax--tag .syntax--name,
+  &.syntax--tag.syntax--inline .syntax--name,
+  &.syntax--tag > .syntax--punctuation {
     color: #96CBFE;
   }
 
-  &.selector.css .entity.name.tag {
+  &.syntax--selector.syntax--css .syntax--entity.syntax--name.syntax--tag {
     text-decoration: underline;
     color: #96CBFE;
   }
 
-  &.selector.css .entity.other.attribute-name.tag.pseudo-class {
+  &.syntax--selector.syntax--css .syntax--entity.syntax--other.syntax--attribute-name.syntax--tag.syntax--pseudo-class {
     color: #8F9D6A;
   }
 
-  &.selector.css .entity.other.attribute-name.id {
+  &.syntax--selector.syntax--css .syntax--entity.syntax--other.syntax--attribute-name.syntax--id {
     color: #8B98AB;
   }
 
-  &.selector.css .entity.other.attribute-name.class {
+  &.syntax--selector.syntax--css .syntax--entity.syntax--other.syntax--attribute-name.syntax--class {
     color: #62B1FE;
   }
 
-  &.property-group .support.constant.property-value.css,
-  &.property-value .support.constant.property-value.css {
+  &.syntax--property-group .syntax--support.syntax--constant.syntax--property-value.syntax--css,
+  &.syntax--property-value .syntax--support.syntax--constant.syntax--property-value.syntax--css {
     color: #F9EE98;
   }
 
-  &.preprocessor.at-rule .keyword.control.at-rule {
+  &.syntax--preprocessor.syntax--at-rule .syntax--keyword.syntax--control.syntax--at-rule {
     color: #8693A5;
   }
 
-  &.property-value .support.constant.named-color.css,
-  &.property-value .constant {
+  &.syntax--property-value .syntax--support.syntax--constant.syntax--named-color.syntax--css,
+  &.syntax--property-value .syntax--constant {
     color: #87C38A;
   }
 
-  &.constructor.argument.css {
+  &.syntax--constructor.syntax--argument.syntax--css {
     color: #8F9D6A;
   }
 
-  &.diff,
-  &.diff.header {
+  &.syntax--diff,
+  &.syntax--diff.syntax--header {
     color: #F8F8F8;
     background-color: #0E2231;
   }
 
-  &.separator {
+  &.syntax--separator {
     color: #60A633;
     background-color: #242424;
   }
 
-  &.line.entry.logfile,
-  &.line.exit.logfile {
+  &.syntax--line.syntax--entry.syntax--logfile,
+  &.syntax--line.syntax--exit.syntax--logfile {
     background-color: rgba(238, 238, 238, 0.16);
   }
 
-  &.line.error.logfile {
+  &.syntax--line.syntax--error.syntax--logfile {
     background-color: #751012;
   }
 }


### PR DESCRIPTION
We are in the process of removing the shadow DOM boundary from `atom-text-editor` elements. This pull request upgrades existing selectors so that they:

* Stop using `:host`.
* Stop using `atom-text-editor::shadow`.
* Prepend syntax class names with `syntax--`.

/cc: @simurai