### PR TITLE
Change attribute color

### DIFF
--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -39,6 +39,6 @@
 @syntax-color-class: #62B1FE;
 @syntax-color-keyword: #96CBFE;
 @syntax-color-tag: #96CBFE;
-@syntax-color-attribute: #C6C5FE;
+@syntax-color-attribute: #FF73FD;
 @syntax-color-import: @syntax-color-keyword;
 @syntax-color-snippet: @syntax-color-constant;

--- a/styles/syntax.less
+++ b/styles/syntax.less
@@ -125,12 +125,12 @@
   color: #96CBFE;
 }
 .syntax--source .syntax--entity.syntax--other.syntax--attribute-name {
-  color: #C6C5FE;
+  color: #FF73FD;
 }
 
 .syntax--entity {
   &.syntax--other.syntax--attribute-name {
-    color: #C6C5FE;
+    color: #FF73FD;
   }
 
   &.syntax--name.syntax--tag.syntax--namespace,
@@ -164,7 +164,7 @@
   &.syntax--tag .syntax--entity,
   &.syntax--tag > .syntax--punctuation,
   &.syntax--tag.syntax--inline .syntax--entity {
-    color: #C6C5FE;
+    color: #FF73FD;
   }
   &.syntax--tag .syntax--name,
   &.syntax--tag.syntax--inline .syntax--name,


### PR DESCRIPTION
### Description of the Change

This PR changes the color for `attribute`s.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/378023/33699137-9ae4b2c8-db54-11e7-89b4-d96737ea0b32.png) | ![image](https://user-images.githubusercontent.com/378023/33699128-8b2463b0-db54-11e7-97c5-f4e2edff7a50.png)


### Alternate Designs

Many options. `#FF73FD` is the same as `.syntax--constant.syntax--numeric`. So might not clash as much?

### Benefits

Easier to differentiate tags and attributes.

### Possible Drawbacks

Some "getting used to".

### Applicable Issues

Closes #45
