### PR TITLE
Increase contrast for comments

### DIFF
--- a/styles/syntax.less
+++ b/styles/syntax.less
@@ -1,5 +1,5 @@
 .syntax--comment {
-  color: #7C7C7C;
+  color: #8a8a8a;
 }
 
 .syntax--entity {
@@ -158,7 +158,7 @@
   &.syntax--xml-processing,
   &.syntax--xml-processing .syntax--entity,
   &.syntax--xml-processing .syntax--string {
-    color: #494949;
+    color: #8a8a8a;
   }
 
   &.syntax--tag .syntax--entity,


### PR DESCRIPTION
### Description of the Change

This increase contrast of comments by `5%`. `DOCTYPE` also got increased.

Before | After
--- | ---
![screen shot 2018-08-24 at 11 31 19 am](https://user-images.githubusercontent.com/378023/44561791-65834b80-a791-11e8-8975-7a9b8a642dd6.png) | ![screen shot 2018-08-24 at 11 30 33 am](https://user-images.githubusercontent.com/378023/44561790-65834b80-a791-11e8-9e4c-3a2e5f6e1ca8.png)



### Alternate Designs

We could increase it even more.

### Benefits

Comments are easier to read

### Possible Drawbacks

Some people might prefer subtler comments

### Applicable Issues

Closes https://github.com/atom/atom-dark-syntax/issues/30
