### PR TITLE
Update README to deprecate repository and redirect readers to atom/atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+### This package is now a part of the [core Atom repository](https://github.com/atom/atom/tree/master/packages/atom-dark-syntax), please direct all issues and pull requests there in the future!
+
+---
+
 # Atom Dark Syntax theme
 
 A dark syntax theme for Atom.


### PR DESCRIPTION
As of atom/atom#18093, the `atom-dark-syntax` package is now a part of the core Atom repository. This pull request updates README.md to reflect that fact. We'll be archiving this repository shortly.

/cc atom/atom#17849